### PR TITLE
Add DynamicResource to expand the stub configuration

### DIFF
--- a/internal/app/handlers/static/static-handler.go
+++ b/internal/app/handlers/static/static-handler.go
@@ -1,6 +1,7 @@
 package static
 
 import (
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"os"
@@ -47,39 +48,18 @@ func SsoToken(w http.ResponseWriter, r *http.Request) {
 	w.Write([]byte("{\"access_token\":\"" + token + "\",\"scope\":\"\",\"exp\":\"9223372036854775807\",\"token_type\":\"bearer\"}"))
 }
 
-// OvirtVms host Vms endpotint
-func OvirtVms(w http.ResponseWriter, r *http.Request) {
-	//TODO: add support for searching with name and cluster name
-	setContentType(w, xmlContentType)
-	content, err := ioutil.ReadFile("stubs/vms/123/content")
+// Dynamic resource for unspecifed url
+func DynamicResource(w http.ResponseWriter, r *http.Request) {
+	setContentType(w, jsonContentType)
+	// Remove from url /ovirt-engine/api prefix
+	path := strings.TrimPrefix(r.URL.Path, "/ovirt-engine/api")
+	// Use the rest of url as path in to get the content
+	content, err := ioutil.ReadFile(fmt.Sprintf("stubs/%s/content", path))
 	if err != nil {
+		fmt.Println(err)
 		w.Write([]byte("<error/>"))
 	}
-	w.Write([]byte("<vms>" + string(content) + "</vms>"))
-}
-
-func OvirtVMSubresource(vmsPrefix string) func(w http.ResponseWriter, r *http.Request) {
-	return func(w http.ResponseWriter, r *http.Request) {
-		vmID := r.URL.Path[len(vmsPrefix):]
-		setContentType(w, xmlContentType)
-		content, err := ioutil.ReadFile("stubs/vms/" + vmID)
-		if err != nil {
-			w.Write([]byte("<error/>"))
-		}
-		w.Write(content)
-	}
-}
-
-func OvirtResoruceHandler(resource string) func(http.ResponseWriter, *http.Request) {
-	return func(w http.ResponseWriter, r *http.Request) {
-		id := r.URL.Query().Get(":id")
-		setContentType(w, xmlContentType)
-		content, err := ioutil.ReadFile("stubs/" + resource + "/" + id + "/content")
-		if err != nil {
-			w.Write([]byte("<error/>"))
-		}
-		w.Write(content)
-	}
+	w.Write(content)
 }
 
 // OvirtDisks host disks endpoint
@@ -93,6 +73,7 @@ func OvirtDisks(w http.ResponseWriter, r *http.Request) {
 	setContentType(w, xmlContentType)
 	content, err := ioutil.ReadFile("stubs/disks/" + id + "/content")
 	if err != nil {
+		fmt.Println(err)
 		w.Write([]byte("<error/>"))
 	}
 	w.Write([]byte(strings.ReplaceAll(string(content), "@DISKSIZE", diskSize)))

--- a/internal/app/routes/routes.go
+++ b/internal/app/routes/routes.go
@@ -2,6 +2,7 @@ package routes
 
 import (
 	"fmt"
+	"net/http"
 
 	"github.com/gorilla/pat"
 
@@ -45,17 +46,10 @@ func ConfigureNamespace(router *pat.Router) {
 
 // ConfigureVms defines the default VM-related routes
 func ConfigureVms(router *pat.Router) {
-	router.HandleFunc(apiEndpoint("vms"), static.OvirtVms)
-	router.HandleFunc(apiEndpoint("vms/{id}"), static.OvirtResoruceHandler("vms"))
-	router.HandleFunc(apiEndpoint("storagedomains/{id}"), static.OvirtResoruceHandler("storagedomains"))
-	router.HandleFunc(apiEndpoint("vnicprofiles/{id}"), static.OvirtResoruceHandler("vnicprofiles"))
-	router.HandleFunc(apiEndpoint("networks/{id}"), static.OvirtResoruceHandler("networks"))
 	router.HandleFunc(apiEndpoint("disks/{id}"), static.OvirtDisks)
 
-	vmSubresourceHandler := static.OvirtVMSubresource(apiEndpoint("/vms"))
-	router.HandleFunc(apiEndpoint("vms/{id}/diskattachments"), vmSubresourceHandler)
-	router.HandleFunc(apiEndpoint("vms/{id}/graphicsconsoles"), vmSubresourceHandler)
-	router.HandleFunc(apiEndpoint("vms/{id}/nics"), vmSubresourceHandler)
+	// When the endpoint is not specified try to get stub from path
+	router.NotFoundHandler = http.HandlerFunc(static.DynamicResource)
 }
 
 func apiEndpoint(path string) string {


### PR DESCRIPTION
Issue: If we would want to expand the stubs with other types we would need to add to each handler.
Fix: When the requested url is not specifed try to find the endpoint in the stubs dir.